### PR TITLE
mab terminates with 1>= candidate. Fixes issue #9

### DIFF
--- a/utils/mab_functions.py
+++ b/utils/mab_functions.py
@@ -224,7 +224,7 @@ def solve_mab(data: np.ndarray, labels: np.ndarray) -> Tuple[int, float, float, 
         )
 
     total_queries = 0
-    while len(candidates) > 0:
+    while len(candidates) > 1:
         # If we have already pulled the arms more times than the number of datapoints in the original dataset,
         # it would be the same complexity to just compute the arm return explicitly over the whole dataset.
         # Do this to avoid scenarios where it may be required to draw \Omega(N) samples to find the best arm.


### PR DESCRIPTION
The only fix is that the main `while` loop for `solve_mab` exits even when there is just one candidate and not just zero. This is to avoid computing the last candidate exactly (if it's the last candidate, it's the best arm by default).
All other commands are identical to the `main` branch.